### PR TITLE
feat: Add unisex gender option and remove duplicate names

### DIFF
--- a/data.json
+++ b/data.json
@@ -3,7 +3,6 @@
         "male": [
             { "name": "Liam", "info": "Trendy und international beliebt" },
             { "name": "Noah", "info": "Zeitlos und modern" },
-            { "name": "Kai", "info": "Kurz, prägnant und cool" },
             { "name": "Finn", "info": "Skandinavisch und hip" },
             { "name": "Leo", "info": "Stark und selbstbewusst" },
             { "name": "Milo", "info": "Süß und einprägsam" },
@@ -11,9 +10,6 @@
             { "name": "Jax", "info": "Moderne Variante von Jack" },
             { "name": "Zion", "info": "Spirituell und kraftvoll" },
             { "name": "Atlas", "info": "Mythologisch und stark" },
-            { "name": "Phoenix", "info": "Symbolisch und einzigartig" },
-            { "name": "River", "info": "Naturverbunden und fließend" },
-            { "name": "Sage", "info": "Weise und geschlechtsneutral" },
             { "name": "Axel", "info": "Rockig und rebellisch" },
             { "name": "Koda", "info": "Nativ-amerikanisch, bedeutet 'Freund'" },
             { "name": "Zander", "info": "Moderne Form von Alexander" },
@@ -35,7 +31,6 @@
             { "name": "Grayson", "info": "Elegant und zeitlos" },
             { "name": "Hendrix", "info": "Rockstar-Vibes" },
             { "name": "Hunter", "info": "Stark und zielstrebig" },
-            { "name": "Indie", "info": "Unabhängig und kreativ" },
             { "name": "Jagger", "info": "Rockig und rebellisch" },
             { "name": "Jasper", "info": "Edelstein-inspiriert" },
             { "name": "Kenzo", "info": "Japanisch und modern" },
@@ -46,7 +41,6 @@
             { "name": "Neo", "info": "Neu und futuristisch" },
             { "name": "Onyx", "info": "Dunkel und mysteriös" },
             { "name": "Paxton", "info": "Friedlich und modern" },
-            { "name": "Rowan", "info": "Naturverbunden und stark" },
             { "name": "Ryker", "info": "Stark und kraftvoll" },
             { "name": "Silas", "info": "Biblisch und trendy" },
             { "name": "Titan", "info": "Mächtig und groß" },
@@ -56,30 +50,34 @@
             { "name": "Zane", "info": "Hebräisch für 'Geschenk'" },
             { "name": "Zephyr", "info": "Wie ein sanfter Wind" }
         ],
+        "unisex": [
+            { "name": "Sage", "info": "Weise und geschlechtsneutral" },
+            { "name": "Phoenix", "info": "Symbolisch und einzigartig" },
+            { "name": "River", "info": "Naturverbunden und fließend" },
+            { "name": "Indie", "info": "Unabhängig und kreativ" },
+            { "name": "Rowan", "info": "Naturverbunden und stark" },
+            { "name": "Quinn", "info": "Stark und geschlechtsneutral" },
+            { "name": "Kai", "info": "Kurz, prägnant und cool" },
+            { "name": "Alex", "info": "Kurzform von Alexander/Alexandra, klassisch unisex" },
+            { "name": "Jordan", "info": "Hebräisch, 'herabfließen', beliebt für alle Geschlechter" },
+            { "name": "Casey", "info": "Irisch, 'wachsam', freundlich und offen" }
+        ],
         "female": [
             { "name": "Luna", "info": "Mystisch und mondschön" },
             { "name": "Aria", "info": "Melodisch und elegant" },
-            { "name": "Nova", "info": "Wie ein neuer Stern" },
-            { "name": "Zara", "info": "Arabisch für 'blühende Blume'" },
             { "name": "Ivy", "info": "Naturverbunden und stark" },
-            { "name": "Sage", "info": "Weise und geschlechtsneutral" },
             { "name": "Willow", "info": "Wie der biegsame Weidenbaum" },
-            { "name": "Phoenix", "info": "Wiedergeburt und Stärke" },
             { "name": "Raven", "info": "Mysteriös und intelligent" },
             { "name": "Skye", "info": "Himmelshoch und grenzenlos" },
-            { "name": "Indie", "info": "Unabhängig und kreativ" },
             { "name": "Wren", "info": "Kleiner Vogel, große Persönlichkeit" },
             { "name": "Ember", "info": "Glühende Leidenschaft" },
             { "name": "Iris", "info": "Regenbogen-Göttin" },
-            { "name": "Nyx", "info": "Göttin der Nacht" },
             { "name": "Rebel", "info": "Aufständisch und frei" },
             { "name": "Storm", "info": "Kraftvoll und unvorhersagbar" },
             { "name": "Celeste", "info": "Himmlisch und strahlend" },
-            { "name": "Lyra", "info": "Sternbild der Leier" },
             { "name": "Kaia", "info": "Erde auf Griechisch" },
             { "name": "Aura", "info": "Geheimnisvolle Ausstrahlung" },
             { "name": "Azalea", "info": "Blume der Leidenschaft" },
-            { "name": "Blaise", "info": "Feuer und Energie" },
             { "name": "Bree", "info": "Frei wie der Wind" },
             { "name": "Cleo", "info": "Ägyptische Königin" },
             { "name": "Dahlia", "info": "Exotische Blume" },
@@ -90,12 +88,10 @@
             { "name": "Indigo", "info": "Tiefblau und mystisch" },
             { "name": "Jade", "info": "Grüner Edelstein" },
             { "name": "Kiara", "info": "Hell und strahlend" },
-            { "name": "Lux", "info": "Licht und Luxus" },
             { "name": "Mira", "info": "Wunder und Schönheit" },
             { "name": "Neve", "info": "Schneeweiß und rein" },
             { "name": "Opal", "info": "Schillernder Edelstein" },
             { "name": "Piper", "info": "Musikalisch und lebhaft" },
-            { "name": "Quinn", "info": "Stark und geschlechtsneutral" },
             { "name": "Rae", "info": "Sonnenstrahlen" },
             { "name": "Scarlett", "info": "Leidenschaftlich rot" },
             { "name": "Talia", "info": "Tau des Himmels" },
@@ -107,8 +103,6 @@
             { "name": "Dara", "info": "Stern der Weisheit" },
             { "name": "Exa", "info": "Technisch und modern" },
             { "name": "Gia", "info": "Gott ist gnädig" },
-            { "name": "Hera", "info": "Griechische Göttin" },
-            { "name": "Juno", "info": "Römische Göttin" },
             { "name": "Kira", "info": "Killer-Ausstrahlung" },
             { "name": "Mila", "info": "Lieblich und sanft" },
             { "name": "Nora", "info": "Licht und Ehre" },
@@ -141,6 +135,13 @@
             { "name": "Andreas", "info": "Der Männliche, Tapfere" },
             { "name": "Felix", "info": "Der Glückliche" }
         ],
+        "unisex": [
+            { "name": "Charlie", "info": "Kurzform von Charles/Charlotte, freundlich und klassisch" },
+            { "name": "Jamie", "info": "Kurzform von James/Jaime, beliebt und etabliert" },
+            { "name": "Robin", "info": "Germanisch, 'glänzend durch Ruhm', auch Naturbezug (Rotkehlchen)" },
+            { "name": "Taylor", "info": "Englisch, 'Schneider', beruflicher Nachname, modern als Vorname" },
+            { "name": "Drew", "info": "Kurzform von Andrew/Andrea, stark und kurz" }
+        ],
         "female": [
             { "name": "Sophie", "info": "Die Weise, aus dem Griechischen" },
             { "name": "Marie", "info": "Die Geliebte, aus dem Hebräischen" },
@@ -161,21 +162,25 @@
     },
     "nature": {
         "male": [
-            { "name": "River", "info": "Fluss, naturverbunden" },
             { "name": "Forest", "info": "Wald, stark und ruhig" },
             { "name": "Stone", "info": "Stein, beständig und solide" },
             { "name": "Ocean", "info": "Ozean, tief und weit" },
-            { "name": "Sky", "info": "Himmel, grenzenlos und frei" },
             { "name": "Clay", "info": "Erde, formbar und natürlich" },
             { "name": "Brooks", "info": "Bach, fließend und klar" },
             { "name": "Glen", "info": "Tal, friedlich und grün" },
             { "name": "Heath", "info": "Heide, wild und ungezähmt" },
             { "name": "Orion", "info": "Sternbild, himmlisch und majestätisch" },
             { "name": "Birch", "info": "Birke, schlank und widerstandsfähig" },
-            { "name": "Lark", "info": "Lerche, frei und singend" },
             { "name": "Reed", "info": "Schilf, flexibel und naturverbunden" },
             { "name": "Wolf", "info": "Wolf, stark und instinktiv" },
             { "name": "Ash", "info": "Esche, alter Baum" }
+        ],
+        "unisex": [
+            { "name": "River", "info": "Fluss, naturverbunden" },
+            { "name": "Sky", "info": "Himmel, grenzenlos und frei" },
+            { "name": "Rowan", "info": "Eberesche, keltischer Baum des Lebens" },
+            { "name": "Lark", "info": "Lerche, frei und singend" },
+            { "name": "Winter", "info": "Jahreszeit, klar und rein" }
         ],
         "female": [
             { "name": "Willow", "info": "Weidenbaum, anmutig und flexibel" },
@@ -184,8 +189,6 @@
             { "name": "Rose", "info": "Rose, klassisch und duftend" },
             { "name": "Dawn", "info": "Morgenröte, Neubeginn und Hoffnung" },
             { "name": "Hazel", "info": "Haselnuss, natürlich und warm" },
-            { "name": "Skye", "info": "Himmel, frei und weit" },
-            { "name": "River", "info": "Fluss, fließend und ruhig" },
             { "name": "Aurora", "info": "Morgenröte, römische Göttin" },
             { "name": "Luna", "info": "Mond, mystisch und strahlend" },
             { "name": "Fern", "info": "Farn, grün und zeitlos" },
@@ -204,14 +207,16 @@
             { "name": "Thorne", "info": "Dorn, kantig und markant" },
             { "name": "Vance", "info": "Seltener englischer Name" },
             { "name": "Xylon", "info": "Aus dem Wald, einzigartig und naturverbunden" },
-            { "name": "Blaise", "info": "Feurig, ungewöhnlich und energisch" },
-            { "name": "Caspian", "info": "Mystisch wie das Meer, elegant" },
-            { "name": "Dax", "info": "Kurz, prägnant und selten" },
-            { "name": "Zane", "info": "Hebräisch für 'Geschenk'" },
             { "name": "Rune", "info": "Geheimnis, nordisch" },
             { "name": "Koa", "info": "Krieger, hawaiianisch" },
-            { "name": "Lior", "info": "Mein Licht, hebräisch" },
-            { "name": "Indigo", "info": "Dunkelblau, einzigartig" }
+            { "name": "Lior", "info": "Mein Licht, hebräisch" }
+        ],
+        "unisex": [
+            { "name": "Indigo", "info": "Dunkelblau, einzigartig und künstlerisch" },
+            { "name": "Blaise", "info": "Feurig, ungewöhnlich und energisch" },
+            { "name": "Jules", "info": "Kurzform von Julian/Julia, modern und schick" },
+            { "name": "Emerson", "info": "Altenglisch, 'Sohn des Emery', literarisch und modern" },
+            { "name": "Sawyer", "info": "Englisch, 'Holzfäller', abenteuerlich und naturverbunden" }
         ],
         "female": [
             { "name": "Lyra", "info": "Sternbild der Leier, melodisch und selten" },
@@ -220,12 +225,10 @@
             { "name": "Aurelia", "info": "Die Goldene, strahlend und klassisch-modern" },
             { "name": "Calista", "info": "Die Schönste, aus dem Griechischen" },
             { "name": "Isolde", "info": "Eis-Herrscherin, mystisch und literarisch" },
-            { "name": "Persephone", "info": "Griechische Göttin, kraftvoll und einzigartig" },
             { "name": "Thalassa", "info": "Meer, aus dem Griechischen, selten" },
             { "name": "Zephyrine", "info": "Sanfter Wind, sehr selten und elegant" },
             { "name": "Xylia", "info": "Aus dem Wald, einzigartig und naturverbunden" },
             { "name": "Fable", "info": "Märchen, einzigartig und erzählerisch" },
-            { "name": "Indigo", "info": "Dunkelblau, künstlerisch" },
             { "name": "Odessa", "info": "Odyssee, abenteuerlich" },
             { "name": "Reverie", "info": "Tagtraum, poetisch" },
             { "name": "Solara", "info": "Sonne, strahlend" }
@@ -244,12 +247,18 @@
             { "name": "Poseidon", "info": "Gott des Meeres (Griechisch)" },
             { "name": "Ra", "info": "Sonnengott (Ägyptisch)" }
         ],
+        "unisex": [
+            { "name": "Phoenix", "info": "Symbol für Wiedergeburt, kulturübergreifend" },
+            { "name": "Artemis", "info": "Griechische Gottheit der Jagd (oft weiblich, aber Name unisex verwendet)" },
+            { "name": "Orion", "info": "Mächtiger Jäger (Griechisch), auch Sternbild" },
+            { "name": "Nyx", "info": "Griechische Gottheit der Nacht (oft weiblich, Name unisex)" },
+            { "name": "Jupiter", "info": "Römischer König der Götter (oft männlich, Name unisex)" }
+        ],
         "female": [
             { "name": "Athena", "info": "Göttin der Weisheit (Griechisch)" },
             { "name": "Freya", "info": "Göttin der Liebe und Schönheit (Nordisch)" },
             { "name": "Isis", "info": "Göttin der Magie (Ägyptisch)" },
             { "name": "Hera", "info": "Königin der Götter (Griechisch)" },
-            { "name": "Artemis", "info": "Göttin der Jagd (Griechisch)" },
             { "name": "Bastet", "info": "Katzengöttin (Ägyptisch)" },
             { "name": "Frigg", "info": "Göttin der Ehe (Nordisch)" },
             { "name": "Persephone", "info": "Königin der Unterwelt (Griechisch)" },
@@ -270,19 +279,21 @@
             { "name": "Nexus", "info": "Verbindungspunkt, zentral" },
             { "name": "Tycho", "info": "Nach Astronom Tycho Brahe" }
         ],
+        "unisex": [
+            { "name": "Nova", "info": "Neuer Stern, hell und kraftvoll" },
+            { "name": "Orion", "info": "Sternbild, kosmisch und stark" },
+            { "name": "Echo", "info": "Widerhall, subtil und modern" },
+            { "name": "Lux", "info": "Licht (Latein), klar und hell" },
+            { "name": "Zen", "info": "Kurz, modern und spirituell" }
+        ],
         "female": [
             { "name": "Lyra", "info": "Sternbild, musikalisch" },
-            { "name": "Nova", "info": "Neuer Stern, hell" },
-            { "name": "Astra", "info": "Sternenhaft, himmlisch" },
             { "name": "Vesper", "info": "Abendstern, geheimnisvoll" },
             { "name": "Celestia", "info": "Himmlisch, erhaben" },
             { "name": "Oriana", "info": "Goldener Sonnenaufgang" },
             { "name": "Seren", "info": "Stern (Walisisch)" },
             { "name": "Andromeda", "info": "Galaxie, mythologisch" },
-            { "name": "Echo", "info": "Widerhall, subtil" },
             { "name": "Juno", "info": "Römische Göttin, königlich" }
         ]
     }
 }
-
-              

--- a/index.html
+++ b/index.html
@@ -47,6 +47,9 @@
             <button class="selection-btn" data-gender="female">
                 <i class="fas fa-venus"></i> (weiblich)
             </button>
+            <button class="selection-btn" data-gender="unisex">
+                <i class="fas fa-genderless"></i> (unisex)
+            </button>
         </div>
         
         <button class="generate-btn" onclick="generateName()">

--- a/script.js
+++ b/script.js
@@ -37,7 +37,7 @@ async function loadNameData() {
         nameData = await response.json();
         // usedNames-Objekt initialisieren, nachdem nameData geladen wurde
         for (const category in nameData) {
-            usedNames[category] = { male: [], female: [] };
+            usedNames[category] = { male: [], female: [], unisex: [] };
         }
         console.log('Namensdaten erfolgreich geladen:', nameData);
 
@@ -189,7 +189,14 @@ function updateFavoritesList() {
         const item = document.createElement('div');
         item.className = 'favorite-item';
         // Emoji für Geschlecht und Kategorie anzeigen
-        const genderEmoji = fav.gender === 'male' ? '♂' : '♀';
+        let genderEmoji = '';
+        if (fav.gender === 'male') {
+            genderEmoji = '♂';
+        } else if (fav.gender === 'female') {
+            genderEmoji = '♀';
+        } else {
+            genderEmoji = '⚧️'; // Transgender symbol for unisex
+        }
         let categoryEmoji = '';
         switch(fav.category) {
             case 'gen-z': categoryEmoji = '🚀'; break;


### PR DESCRIPTION
- Added 'unisex' as a selectable gender option.
- Updated data.json to include unisex names for all categories, moving existing suitable names and adding new ones.
- Updated index.html to include a button for unisex selection with the 'fa-genderless' icon.
- Updated script.js to handle unisex gender selection, name generation, favorites, and used names logic.
- Performed a thorough deduplication of names within data.json to ensure each name is unique or appropriately categorized.
- Tested all changes, including name generation, favorites, used names tracking, gender switching, and local storage persistence.